### PR TITLE
Add remove-vaultauthority command

### DIFF
--- a/src/main/java/org/cryptomator/hubcli/Backend.java
+++ b/src/main/java/org/cryptomator/hubcli/Backend.java
@@ -102,6 +102,11 @@ public class Backend implements AutoCloseable {
 			return sendRequest(httpClient, vaultKeyReq, HttpResponse.BodyHandlers.ofString(StandardCharsets.US_ASCII), 200);
 		}
 
+		public HttpResponse<Void> removeAuthority(UUID vaultId, String authorityId) throws IOException, InterruptedException, UnexpectedStatusCodeException {
+			var req = createRequest("vaults/" + vaultId + "/authority/" + authorityId).DELETE().build();
+			return sendRequest(httpClient, req, HttpResponse.BodyHandlers.discarding(), 204);
+		}
+
 	}
 
 	class UserService {

--- a/src/main/java/org/cryptomator/hubcli/HubCli.java
+++ b/src/main/java/org/cryptomator/hubcli/HubCli.java
@@ -10,7 +10,7 @@ import picocli.CommandLine.Command;
 		subcommands = {Login.class, CreateVault.class, UpdateVault.class, //
 				GetRecoveryKey.class, AddVaultUser.class, AddVaultGroup.class, //
 				ListVaults.class, ListGroups.class, ListUsers.class, //
-				Setup.class, //
+				RemoveVaultAuthority.class, Setup.class //
 		})
 class HubCli {
 


### PR DESCRIPTION
~Requires backend to be refactored before merging, currently there is DELETE `/{vaultId}/groups/{groupId}` and DELETE `/{vaultId}/users/{userId}` but IMO we should refactor it to DELETE `/{vaultId}/authority/{userId}`~

Backend is refactored :)