### PR TITLE
Feature: Add CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
         run: >
-          mvn -B clean package -Pjar
+          mvn -B clean verify -Pjar,dependency-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,17 @@ jobs:
             target/dependency-check-report.html
             target/surefire-reports/*
           if-no-files-found: error
+      - name: Draft a release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          token: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }}
+          generate_release_notes: true
+          body: |-
+            :construction: Work in Progress
+            
+            ⏳ Please be patient, the builds are still [running](https://github.com/cryptomator/cryptomator/actions). New versions of Cryptomator can be found here in a few moments. ⏳
+            
+            ---
+            <!-- Don't forget to include the 💾 SHA-256 checksums of release artifacts: -->

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
         run: >
-          mvn -B clean verify -Pjar,dependency-check
+          mvn -B clean verify -Pdependency-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
       - name: Upload reports 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,11 @@ jobs:
           mvn -B clean verify -Pjar,dependency-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+      - name: Upload reports 
+        uses: actions/upload-artifact@v3
+        with:
+          name: hub-cli-reports
+          path: |
+            target/dependency-check-report.html
+            target/surefire-reports/*
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,7 @@ jobs:
       - name: Build and Test
         run: >
           mvn -B clean verify -Pdependency-check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-      - name: Upload reports 
+      - name: Upload reports
         uses: actions/upload-artifact@v3
         with:
           name: hub-cli-reports
@@ -44,7 +42,7 @@ jobs:
           body: |-
             :construction: Work in Progress
             
-            ⏳ Please be patient, the builds are still [running](https://github.com/cryptomator/cryptomator/actions). New versions of Cryptomator can be found here in a few moments. ⏳
+            ⏳ Please be patient, the builds are still [running](https://github.com/cryptomator/hub-cli/actions). New versions of hub-cli can be found here in a few moments. ⏳
             
             ---
             <!-- Don't forget to include the 💾 SHA-256 checksums of release artifacts: -->

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           java-version: '21.0.1'
           distribution: 'graalvm' # See 'Options' for all available distributions
+          cache: 'maven'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
         run: >

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -22,8 +22,6 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: >
           mvn -B clean package -Pnative
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
       - name: Build release native image
         if: startsWith(github.ref, 'refs/tags/')
         run: >

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -1,6 +1,10 @@
 name: Build native image
 
-on: workflow_dispatch
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
 
 jobs:
   build:
@@ -26,4 +30,11 @@ jobs:
           path: |
             target/hub
           if-no-files-found: error
-
+      - name: Publish executable on Github Releases
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          fail_on_unmatched_files: true
+          token: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }}
+          files: |
+            target/hub

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -26,10 +26,14 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: >
           mvn -B clean package -Pnative,release
-      - name: Create detached GPG signatures
+      - name: Create detached GPG signatures with key 615D449FE6E6A235
         run: |
-          gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a target/hub
-          gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a target/HubCli_completion.sh
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --quiet --import
+          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a target/hub
+          echo "${GPG_PASSPHRASE}" | gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a target/HubCli_completion.sh
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
       - name: Upload executable
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           java-version: '21.0.1'
           distribution: 'graalvm'
+          cache: 'maven'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build native image
         run: >

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -34,6 +34,7 @@ jobs:
           name: hub-cli
           path: |
             target/hub
+            target/HubCli_completion.sh
           if-no-files-found: error
       - name: Publish executable on Github Releases
         if: startsWith(github.ref, 'refs/tags/')
@@ -43,3 +44,4 @@ jobs:
           token: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }}
           files: |
             target/hub
+            target/HubCli_completion.sh

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -26,6 +26,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: >
           mvn -B clean package -Pnative,release
+      - name: Create detached GPG signatures
+        run: |
+          gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a target/hub
+          gpg --batch --quiet --passphrase-fd 0 --pinentry-mode loopback -u 615D449FE6E6A235 --detach-sign -a target/HubCli_completion.sh
       - name: Upload executable
         uses: actions/upload-artifact@v3
         with:
@@ -33,6 +37,8 @@ jobs:
           path: |
             target/hub
             target/HubCli_completion.sh
+            hub.asc
+            HubCli_completion*.asc
           if-no-files-found: error
       - name: Publish executable on Github Releases
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -49,3 +49,5 @@ jobs:
           files: |
             target/hub
             target/HubCli_completion.sh
+            hub.asc
+            HubCli_completion*.asc

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -18,11 +18,16 @@ jobs:
           distribution: 'graalvm'
           cache: 'maven'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build native image
+      - name: Build develop native image
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: >
           mvn -B clean package -Pnative
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+      - name: Build release native image
+        if: startsWith(github.ref, 'refs/tags/')
+        run: >
+          mvn -B clean package -Pnative,release
       - name: Upload executable
         uses: actions/upload-artifact@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,7 @@
 					<plugin>
 						<groupId>org.owasp</groupId>
 						<artifactId>dependency-check-maven</artifactId>
+						<version>${dependency-check.version}</version>
 						<configuration>
 							<cveValidForHours>24</cveValidForHours>
 							<failBuildOnCVSS>0</failBuildOnCVSS>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>21</java.version>
+		<!-- native image options -->
 		<mainClass>org.cryptomator.hubcli.HubCli</mainClass>
+		<native.optimizations>-Ob</native.optimizations> <!-- default: no optimization-->
 
 		<!-- runtime dependencies -->
 		<tinyoauth2.version>0.8.0</tinyoauth2.version>
@@ -189,10 +191,10 @@
 
 	<profiles>
 		<profile>
-			<id>jar</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
+			<id>release</id>
+			<properties>
+				<native.optimizations>-O3</native.optimizations>
+			</properties>
 			<build>
 			</build>
 		</profile>
@@ -224,6 +226,7 @@
 						</executions>
 						<configuration>
 							<buildArgs>
+								<arg>${native.optimization}</arg>
 								<arg>--initialize-at-build-time=org.cryptomator.hubcli.util.LoggerInitializer</arg>
 								<!--                                <arg>&#45;&#45;native-compiler-path="C:\graal-native-compiler\Tools\MSVC\14.37.32822\bin\Hostx64\x64\cl.exe"</arg>-->
 							</buildArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<java.version>21</java.version>
 		<!-- native image options -->
 		<mainClass>org.cryptomator.hubcli.HubCli</mainClass>
-		<native.optimizations>-Ob</native.optimizations> <!-- default: no optimization-->
+		<native.optimization>-Ob</native.optimization> <!-- default: no optimization/dev build-->
 
 		<!-- runtime dependencies -->
 		<tinyoauth2.version>0.8.0</tinyoauth2.version>
@@ -193,7 +193,7 @@
 		<profile>
 			<id>release</id>
 			<properties>
-				<native.optimizations>-O3</native.optimizations>
+				<native.optimization>-O3</native.optimization>
 			</properties>
 			<build>
 			</build>

--- a/suppression.xml
+++ b/suppression.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file lists false positives found by org.owasp:dependency-check-maven build plugin -->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        Guava FileBackedOutputStream not used
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <cve>CVE-2020-8908</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Guava API com.google.common.io.Files.createTempDir() not used
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <cve>CVE-2023-2976</cve>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
This PR adds CI to the project by using Github Actions.

Two workflows exists:
* build: to build and test the JAR. It is triggered on push/tag. If the github ref is a tag, then a release is drafted. The workflow uploads reports like dependency-check or surefire
* native-image: to build a native image with graal VM. Triggerd manually or on a published release. In the latter case, the image is build with higher optimization. Afterwards, the executable and the autocompletion file is uploaded.