### PR TITLE
Better handling when Cryptomator Hub CLI needs to be set up

### DIFF
--- a/src/main/java/org/cryptomator/hubcli/Backend.java
+++ b/src/main/java/org/cryptomator/hubcli/Backend.java
@@ -102,7 +102,15 @@ class Backend implements AutoCloseable {
 
 		public HttpResponse<String> getAccessToken(UUID vaultId) throws IOException, InterruptedException, UnexpectedStatusCodeException {
 			var vaultKeyReq = createRequest("vaults/" + vaultId + "/access-token").GET().build();
-			return sendRequest(httpClient, vaultKeyReq, HttpResponse.BodyHandlers.ofString(StandardCharsets.US_ASCII), 200);
+			try {
+				return sendRequest(httpClient, vaultKeyReq, HttpResponse.BodyHandlers.ofString(StandardCharsets.US_ASCII), 200);
+			} catch (UnexpectedStatusCodeException e) {
+				if (e.status == 449) {
+					throw new UnexpectedStatusCodeException(e.status, "Cryptomator Hub CLI is not setup. Execute the setup command first.");
+				} else {
+					throw e;
+				}
+			}
 		}
 
 		public HttpResponse<Void> removeAuthority(UUID vaultId, String authorityId) throws IOException, InterruptedException, UnexpectedStatusCodeException {

--- a/src/main/java/org/cryptomator/hubcli/Backend.java
+++ b/src/main/java/org/cryptomator/hubcli/Backend.java
@@ -106,7 +106,7 @@ class Backend implements AutoCloseable {
 				return sendRequest(httpClient, vaultKeyReq, HttpResponse.BodyHandlers.ofString(StandardCharsets.US_ASCII), 200);
 			} catch (UnexpectedStatusCodeException e) {
 				if (e.status == 449) {
-					throw new UnexpectedStatusCodeException(e.status, "Cryptomator Hub CLI is not setup. Execute the setup command first.");
+					throw new SetupRequiredStatusCodeException(e);
 				} else {
 					throw e;
 				}

--- a/src/main/java/org/cryptomator/hubcli/SetupRequiredStatusCodeException.java
+++ b/src/main/java/org/cryptomator/hubcli/SetupRequiredStatusCodeException.java
@@ -1,0 +1,15 @@
+package org.cryptomator.hubcli;
+
+class SetupRequiredStatusCodeException extends UnexpectedStatusCodeException {
+
+	private static final int STATUS = 449;
+	private static final String MESSAGE = "Cryptomator Hub CLI is not setup. Execute the setup command first.";
+
+	public SetupRequiredStatusCodeException() {
+		super(STATUS, MESSAGE);
+	}
+
+	public SetupRequiredStatusCodeException(UnexpectedStatusCodeException e) {
+		super(e, STATUS, MESSAGE);
+	}
+}

--- a/src/main/java/org/cryptomator/hubcli/UnexpectedStatusCodeException.java
+++ b/src/main/java/org/cryptomator/hubcli/UnexpectedStatusCodeException.java
@@ -9,6 +9,11 @@ class UnexpectedStatusCodeException extends Exception {
 		this.status = status;
 	}
 
+	public UnexpectedStatusCodeException(Throwable throwable, int status, String message) {
+		super(message, throwable);
+		this.status = status;
+	}
+
 	/**
 	 * Subtracts 300 from HTTP status codes to make most codes (400-555) fit into an unsigned byte
 	 * @return A value suitable for use as exit code (0-255)

--- a/src/main/java/org/cryptomator/hubcli/UnexpectedStatusCodeException.java
+++ b/src/main/java/org/cryptomator/hubcli/UnexpectedStatusCodeException.java
@@ -2,7 +2,7 @@ package org.cryptomator.hubcli;
 
 class UnexpectedStatusCodeException extends Exception {
 
-	private final int status;
+	final int status;
 
 	public UnexpectedStatusCodeException(int status, String message) {
 		super(message);

--- a/src/main/java/org/cryptomator/hubcli/VaultCreate.java
+++ b/src/main/java/org/cryptomator/hubcli/VaultCreate.java
@@ -61,6 +61,10 @@ class VaultCreate implements Callable<Integer> {
 		var csprng = SecureRandom.getInstanceStrong();
 		try (var backend = new Backend(parentCmd.accessToken.value, parentCmd.common.getApiBase()); var masterkey = Masterkey.generate(csprng)) {
 			var user = backend.getUserService().getMe(false);
+			if (user.publicKey() == null) {
+				LOG.error("Cryptomator Hub CLI is not setup. Execute the setup command first.");
+				return 1;
+			}
 			var userPublicKeyBytes = BaseEncoding.base64().decode(user.publicKey());
 			var userPublicKey = KeyHelper.readX509EncodedEcPublicKey(userPublicKeyBytes);
 

--- a/src/main/java/org/cryptomator/hubcli/VaultCreate.java
+++ b/src/main/java/org/cryptomator/hubcli/VaultCreate.java
@@ -62,8 +62,7 @@ class VaultCreate implements Callable<Integer> {
 		try (var backend = new Backend(parentCmd.accessToken.value, parentCmd.common.getApiBase()); var masterkey = Masterkey.generate(csprng)) {
 			var user = backend.getUserService().getMe(false);
 			if (user.publicKey() == null) {
-				LOG.error("Cryptomator Hub CLI is not setup. Execute the setup command first.");
-				return 1;
+				throw new SetupRequiredStatusCodeException();
 			}
 			var userPublicKeyBytes = BaseEncoding.base64().decode(user.publicKey());
 			var userPublicKey = KeyHelper.readX509EncodedEcPublicKey(userPublicKeyBytes);


### PR DESCRIPTION
This PR displays the required setup when it is needed:
* creating a vault
* retrieving the recovery key
* adding a user/group.