### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
     name: Compile and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: graalvm/setup-graalvm@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
+      - uses: graalvm/setup-graalvm@54b4f5a65c1a84b2fdfdc2078fe43df32819e4b1 #v1.4.5
         with:
           java-version: '21.0.1'
           distribution: 'graalvm' # See 'Options' for all available distributions
@@ -25,7 +25,7 @@ jobs:
         run: >
           mvn -B clean verify
       - name: Upload reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: hub-cli-reports
           path: |
@@ -34,7 +34,7 @@ jobs:
           if-no-files-found: error
       - name: Draft a release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           draft: true
           token: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }}

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,7 +1,7 @@
 name: OWASP Maven Dependency Check
 on:
   schedule:
-    - cron: '0 23 * * 0'
+    - cron: '0 12 * * 0'
   push:
     branches:
       - 'release/**'
@@ -10,11 +10,13 @@ on:
 
 jobs:
   check-dependencies:
-    uses: skymatic/workflows/.github/workflows/run-dependency-check.yml@v1
+    uses: skymatic/workflows/.github/workflows/run-dependency-check.yml@957d3c2c08c56855fdac41e5afb9a7aca8c30dd9 # v3.0.3
     with:
       runner-os: 'ubuntu-latest'
       java-distribution: 'temurin'
-      java-version: 21
+      java-version: 25
     secrets:
       nvd-api-key: ${{ secrets.NVD_API_KEY }}
-      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      ossindex-username: ${{ secrets.OSSINDEX_USERNAME }}
+      ossindex-token: ${{ secrets.OSSINDEX_API_TOKEN }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_CRYPTOMATOR_DESKTOP }}

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build a native image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
       - uses: graalvm/setup-graalvm@54b4f5a65c1a84b2fdfdc2078fe43df32819e4b1 #v1.4.5
         with:
           java-version: '21.0.1'

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -11,8 +11,8 @@ jobs:
     name: Build a native image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: graalvm/setup-graalvm@v1
+      - uses: actions/checkout@@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
+      - uses: graalvm/setup-graalvm@54b4f5a65c1a84b2fdfdc2078fe43df32819e4b1 #v1.4.5
         with:
           java-version: '21.0.1'
           distribution: 'graalvm'
@@ -38,7 +38,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
       - name: Upload executable
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: hub-cli
           path: |
@@ -49,7 +49,7 @@ jobs:
           if-no-files-found: error
       - name: Publish executable on Github Releases
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           fail_on_unmatched_files: true
           token: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }}


### PR DESCRIPTION
Pin all GitHub Actions and reusable workflows to immutable commit SHAs instead of version tags.
This improves supply-chain security.